### PR TITLE
switch to latitude and longitude property props instead of lat lng

### DIFF
--- a/src/LeafletMap/PropertyIcons/index.js
+++ b/src/LeafletMap/PropertyIcons/index.js
@@ -10,8 +10,8 @@ class PropertyIcons extends React.Component {
   }
 
   getLatLng(result) {
-    if (result.lat && result.lng) {
-      return [result.lat, result.lng]
+    if (result.latitude && result.longitude) {
+      return [result.latitude, result.longitude]
     }
   }
 

--- a/src/Lookup/AddressSearch/__tests__/addressSearch.integration.test.js
+++ b/src/Lookup/AddressSearch/__tests__/addressSearch.integration.test.js
@@ -14,6 +14,8 @@ const mock = new MockAdapter(Axios)
 
 import AddressSearch from 'Lookup/AddressSearch'
 
+jest.mock('lodash/debounce', () => jest.fn(fn => fn))
+
 configure({ adapter: new Adapter() })
 beforeEach(() => {
   jest.useFakeTimers()

--- a/src/Lookup/LookupProfileSummary/index.js
+++ b/src/Lookup/LookupProfileSummary/index.js
@@ -105,8 +105,8 @@ const LookupProfileSummary = props => {
                         >
                           <LocationSection
                             appState={props.appState}
-                            lat={props.propertyResult.lat}
-                            lng={props.propertyResult.lng}
+                            lat={props.propertyResult.latitude}
+                            lng={props.propertyResult.longitude}
                             propertyResult={props.propertyResult}
                           />
                         </ExpandableSection>


### PR DESCRIPTION
I deprecated the lat/lng fields on the property model in https://github.com/ANHD-NYC-CODE/anhd-council-backend/pull/19

So this is the corresponding frontend change to use the newer `latitude` and `longitude` props 

plus a test fix. lodash? :)